### PR TITLE
stream.push() after EOF

### DIFF
--- a/lib/write-limiter.js
+++ b/lib/write-limiter.js
@@ -8,6 +8,9 @@ function Limiter(options) {
   this.interval = interval
   this.lastPush = 0;
   this.timeout = null;
+  this.on('finish', function() {
+    clearTimeout(this.timeout);
+  });
 }
 util.inherits(Limiter, Transform);
 


### PR DESCRIPTION
If you call end() on the limiter you get an error because the timer runs after the stream has ended.

```
Error: stream.push() after EOF
    at readableAddChunk (_stream_readable.js:132:15)
    at Limiter.Readable.push (_stream_readable.js:110:10)
    at Limiter.Transform.push (_stream_transform.js:128:32)
    at Limiter.<anonymous> (node_modules/write-limiter/lib/write-limiter.js:21:10)
    at Timer.listOnTimeout (timers.js:89:15)
```
